### PR TITLE
Test: Add Unit Tests

### DIFF
--- a/ProtoCredentials/OpenId4VC-Tests/OpenId4VC-Tests.csproj
+++ b/ProtoCredentials/OpenId4VC-Tests/OpenId4VC-Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/ProtoCredentials/OpenId4VC-Tests/OpenId4VC-Tests.csproj
+++ b/ProtoCredentials/OpenId4VC-Tests/OpenId4VC-Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>OpenId4VC_Tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenID4VC-Prototype\OpenID4VC-Prototype.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/ProtoCredentials/OpenId4VC-Tests/OpenId4VC-Tests.csproj
+++ b/ProtoCredentials/OpenId4VC-Tests/OpenId4VC-Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/ProtoCredentials/OpenId4VC-Tests/Services/DIdServiceTests.cs
+++ b/ProtoCredentials/OpenId4VC-Tests/Services/DIdServiceTests.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Extensions.Options;
-using Moq;
+﻿using FakeItEasy;
+using Microsoft.Extensions.Options;
 using OpenID4VC_Prototype.Configurations;
 using OpenID4VC_Prototype.Services;
 
@@ -16,10 +16,11 @@ public class DIdServiceTests
             DIdPrefix = "did:example:"
         };
 
-        var mockOptions = new Mock<IOptions<DIdConfiguration>>();
-        mockOptions.Setup(o => o.Value).Returns(didSettings);
+        var fakeOptions = A.Fake<IOptions<DIdConfiguration>>();
 
-        var dIdService = new DIdService(mockOptions.Object);
+        A.CallTo(() => fakeOptions.Value).Returns(didSettings);
+
+        var dIdService = new DIdService(fakeOptions);
 
         // Act
         var dId = dIdService.GenerateDId();

--- a/ProtoCredentials/OpenId4VC-Tests/Services/DIdServiceTests.cs
+++ b/ProtoCredentials/OpenId4VC-Tests/Services/DIdServiceTests.cs
@@ -20,10 +20,10 @@ public class DIdServiceTests
 
         A.CallTo(() => fakeOptions.Value).Returns(didSettings);
 
-        var dIdService = new DIdService(fakeOptions);
+        var mockDIdService = new DIdService(fakeOptions);
 
         // Act
-        var dId = dIdService.GenerateDId();
+        var dId = mockDIdService.GenerateDId();
 
         // Assert
         Assert.StartsWith("did:example:", dId.DId);

--- a/ProtoCredentials/OpenId4VC-Tests/Services/DIdServiceTests.cs
+++ b/ProtoCredentials/OpenId4VC-Tests/Services/DIdServiceTests.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Extensions.Options;
+using Moq;
+using OpenID4VC_Prototype.Configurations;
+using OpenID4VC_Prototype.Services;
+
+namespace OpenId4VC_Tests.Services;
+public class DIdServiceTests
+{
+    [Fact]
+    public void GenerateDId_ShouldReturnValidDId()
+    {
+        // Arrange
+        var didSettings = new DIdConfiguration()
+        {
+            DefaultKeySize = 2048,
+            DIdPrefix = "did:example:"
+        };
+
+        var mockOptions = new Mock<IOptions<DIdConfiguration>>();
+        mockOptions.Setup(o => o.Value).Returns(didSettings);
+
+        var dIdService = new DIdService(mockOptions.Object);
+
+        // Act
+        var dId = dIdService.GenerateDId();
+
+        // Assert
+        Assert.StartsWith("did:example:", dId.DId);
+        Assert.InRange(dId.DId.Length, 48, 48);
+    }
+}

--- a/ProtoCredentials/ProtoCredentials.sln
+++ b/ProtoCredentials/ProtoCredentials.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.12.35707.178 d17.12
+VisualStudioVersion = 17.12.35707.178
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenID4VC-Prototype", "OpenID4VC-Prototype\OpenID4VC-Prototype.csproj", "{C00459D4-0F61-4F2A-9996-A2B7DCC96ED5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenId4VC-Tests", "OpenId4VC-Tests\OpenId4VC-Tests.csproj", "{7FE9A3B4-8B30-4FD6-9EAE-111AE8E787B5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{C00459D4-0F61-4F2A-9996-A2B7DCC96ED5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C00459D4-0F61-4F2A-9996-A2B7DCC96ED5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C00459D4-0F61-4F2A-9996-A2B7DCC96ED5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7FE9A3B4-8B30-4FD6-9EAE-111AE8E787B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FE9A3B4-8B30-4FD6-9EAE-111AE8E787B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FE9A3B4-8B30-4FD6-9EAE-111AE8E787B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7FE9A3B4-8B30-4FD6-9EAE-111AE8E787B5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
# Description
xUnit project is added in order to better cover prototype code.

Only happy path test for `DIdService` is added in this PR.

This will help with further developing functionalities, especially as the project becomes more robust.