### PR TITLE
Feat: Add JWT Based VCs

### DIFF
--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Interfaces/IIssuerService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Interfaces/IIssuerService.cs
@@ -5,4 +5,5 @@ namespace OpenID4VC_Prototype.Application.Interfaces;
 public interface IIssuerService
 {
     VCDto IssueCredential(DIdDto issuer, string holderDId);
+    string IssueJwtVc(DIdDto issuer, string holderDId);
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Interfaces/IIssuerService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Interfaces/IIssuerService.cs
@@ -5,5 +5,5 @@ namespace OpenID4VC_Prototype.Application.Interfaces;
 public interface IIssuerService
 {
     VCDto IssueCredential(DIdDto issuer, string holderDId);
-    string IssueJwtVc(DIdDto issuer, string holderDId);
+    string IssueJwtCredential(DIdDto issuer, string holderDId);
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Interfaces/IVerifierService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Interfaces/IVerifierService.cs
@@ -5,4 +5,5 @@ namespace OpenID4VC_Prototype.Application.Interfaces;
 public interface IVerifierService
 {
     ValidationResult ValidateCredential(VCDto credential, string issuerPublicKey);
+    ValidationResult ValidateJwtVc(string jwtVc);
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Interfaces/IVerifierService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Interfaces/IVerifierService.cs
@@ -1,5 +1,4 @@
-﻿using System.Security.Cryptography;
-using OpenID4VC_Prototype.Application.Models;
+﻿using OpenID4VC_Prototype.Application.Models;
 
 namespace OpenID4VC_Prototype.Application.Interfaces;
 

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Interfaces/IVerifierService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Interfaces/IVerifierService.cs
@@ -5,5 +5,5 @@ namespace OpenID4VC_Prototype.Application.Interfaces;
 public interface IVerifierService
 {
     ValidationResult ValidateCredential(VCDto credential, string issuerPublicKey);
-    ValidationResult ValidateJwtVc(string jwtVc, string publicKey);
+    ValidationResult ValidateJwtCredential(string jwtVc, string publicKey);
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Interfaces/IVerifierService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Interfaces/IVerifierService.cs
@@ -1,9 +1,10 @@
-﻿using OpenID4VC_Prototype.Application.Models;
+﻿using System.Security.Cryptography;
+using OpenID4VC_Prototype.Application.Models;
 
 namespace OpenID4VC_Prototype.Application.Interfaces;
 
 public interface IVerifierService
 {
     ValidationResult ValidateCredential(VCDto credential, string issuerPublicKey);
-    ValidationResult ValidateJwtVc(string jwtVc);
+    ValidationResult ValidateJwtVc(string jwtVc, string publicKey);
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Services/IssuerService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Services/IssuerService.cs
@@ -8,7 +8,7 @@ using Serilog;
 
 namespace OpenID4VC_Prototype.Application.Services;
 
-public class IssuerService(ICryptoService cryptoService) : IIssuerService
+public class IssuerService(ICryptoService cryptoService, IJwtService jwtService) : IIssuerService
 {
     public VCDto IssueCredential(DIdDto issuer, string holderDId)
     {
@@ -32,5 +32,30 @@ public class IssuerService(ICryptoService cryptoService) : IIssuerService
         credential.Signature = cryptoService.SignData(credential, issuer.PrivateKey);
 
         return credential.Adapt<VCDto>();
+    }
+
+    public string IssueJwtVc(DIdDto issuer, string holderDId)
+    {
+        Log.Information($"Issuing credential for holder DID: {holderDId}");
+
+        if (!DIdValidators.IsValidDId(holderDId))
+            throw new ArgumentException($"Invalid holder DID: {holderDId}");
+
+        var credential = new VerifiableCredential
+        {
+            IssuerDId = issuer.DId,
+            HolderDId = holderDId,
+            CredentialType = "Diploma",
+            Claims = new Dictionary<string, string>
+            {
+                { "University", "PMF" },
+                { "Curriculum", "Mathematics" }
+            }
+        };
+
+        credential.Signature = cryptoService.SignData(credential, issuer.PrivateKey);
+
+        var jwcVc = jwtService.CreateJwtVc(credential);
+        return jwcVc;
     }
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Services/IssuerService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Services/IssuerService.cs
@@ -55,7 +55,7 @@ public class IssuerService(ICryptoService cryptoService, IJwtService jwtService)
 
         credential.Signature = cryptoService.SignData(credential, issuer.PrivateKey);
 
-        var jwcVc = jwtService.CreateJwtVc(credential);
+        var jwcVc = jwtService.CreateJwtVc(credential, issuer.PrivateKey);
         return jwcVc;
     }
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Services/IssuerService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Services/IssuerService.cs
@@ -49,11 +49,13 @@ public class IssuerService(ICryptoService cryptoService, IJwtService jwtService)
             Claims = new Dictionary<string, string>
             {
                 { "University", "PMF" },
-                { "Curriculum", "Mathematics" }
+                { "Curriculum", "Informatics" }
             }
         };
 
         credential.Signature = cryptoService.SignData(credential, issuer.PrivateKey);
+
+        Log.Information($"Issued credential: {credential.CredentialType} for {credential.HolderDId}");
 
         var jwcVc = jwtService.CreateJwtVc(credential, issuer.PrivateKey);
         return jwcVc;

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Services/IssuerService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Services/IssuerService.cs
@@ -34,7 +34,7 @@ public class IssuerService(ICryptoService cryptoService, IJwtService jwtService)
         return credential.Adapt<VCDto>();
     }
 
-    public string IssueJwtVc(DIdDto issuer, string holderDId)
+    public string IssueJwtCredential(DIdDto issuer, string holderDId)
     {
         Log.Information($"Issuing credential for holder DID: {holderDId}");
 

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Services/VerifierService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Services/VerifierService.cs
@@ -8,7 +8,7 @@ using Serilog;
 
 namespace OpenID4VC_Prototype.Application.Services;
 
-public class VerifierService(ICryptoService cryptoService) : IVerifierService
+public class VerifierService(ICryptoService cryptoService, IJwtService jwtService) : IVerifierService
 {
     public ValidationResult ValidateCredential(VCDto credential, string issuerPublicKey)
     {
@@ -23,6 +23,15 @@ public class VerifierService(ICryptoService cryptoService) : IVerifierService
             return new ValidationResult(false, "Issuer public key is missing");
 
         var isValid = cryptoService.VerifySignature(domainCredential, issuerPublicKey);
+
+        return isValid
+            ? new ValidationResult(true)
+            : new ValidationResult(false, "Signature verification failed");
+    }
+
+    public ValidationResult ValidateJwtVc(string jwtVc)
+    {
+        var isValid = jwtService.ValidateJwtVc(jwtVc);
 
         return isValid
             ? new ValidationResult(true)

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Services/VerifierService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Services/VerifierService.cs
@@ -1,4 +1,5 @@
-﻿using Mapster;
+﻿using System.Security.Cryptography;
+using Mapster;
 using OpenID4VC_Prototype.Application.Interfaces;
 using OpenID4VC_Prototype.Application.Models;
 using OpenID4VC_Prototype.Domain.Interfaces;
@@ -29,9 +30,9 @@ public class VerifierService(ICryptoService cryptoService, IJwtService jwtServic
             : new ValidationResult(false, "Signature verification failed");
     }
 
-    public ValidationResult ValidateJwtVc(string jwtVc)
+    public ValidationResult ValidateJwtVc(string jwtVc, string publicKey)
     {
-        var isValid = jwtService.ValidateJwtVc(jwtVc);
+        var isValid = jwtService.ValidateJwtVc(jwtVc, publicKey);
 
         return isValid
             ? new ValidationResult(true)

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Services/VerifierService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Services/VerifierService.cs
@@ -1,5 +1,4 @@
-﻿using System.Security.Cryptography;
-using Mapster;
+﻿using Mapster;
 using OpenID4VC_Prototype.Application.Interfaces;
 using OpenID4VC_Prototype.Application.Models;
 using OpenID4VC_Prototype.Domain.Interfaces;
@@ -32,6 +31,11 @@ public class VerifierService(ICryptoService cryptoService, IJwtService jwtServic
 
     public ValidationResult ValidateJwtVc(string jwtVc, string publicKey)
     {
+        Log.Information($"Verifying credential for holder"); // todo: deserialize jwt to log information
+
+        if (string.IsNullOrEmpty(jwtVc))
+            return new ValidationResult(false, "Invalid token presented");
+
         var isValid = jwtService.ValidateJwtVc(jwtVc, publicKey);
 
         return isValid

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Services/VerifierService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Services/VerifierService.cs
@@ -1,4 +1,5 @@
 ﻿using Mapster;
+using Microsoft.IdentityModel.JsonWebTokens;
 using OpenID4VC_Prototype.Application.Interfaces;
 using OpenID4VC_Prototype.Application.Models;
 using OpenID4VC_Prototype.Domain.Interfaces;
@@ -31,7 +32,11 @@ public class VerifierService(ICryptoService cryptoService, IJwtService jwtServic
 
     public ValidationResult ValidateJwtCredential(string jwtVc, string publicKey)
     {
-        Log.Information($"Verifying credential for holder"); // todo: deserialize jwt to log information
+        var handler = new JsonWebTokenHandler();
+        var token = handler.ReadJsonWebToken(jwtVc);
+        var holder = token.Claims.ToList()[0];
+
+        Log.Information($"Verifying credential for holder: {holder}");
 
         if (string.IsNullOrEmpty(jwtVc))
             return new ValidationResult(false, "Invalid token presented");

--- a/ProtoCredentials/OpenID4VC-Prototype/Application/Services/VerifierService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Application/Services/VerifierService.cs
@@ -29,7 +29,7 @@ public class VerifierService(ICryptoService cryptoService, IJwtService jwtServic
             : new ValidationResult(false, "Signature verification failed");
     }
 
-    public ValidationResult ValidateJwtVc(string jwtVc, string publicKey)
+    public ValidationResult ValidateJwtCredential(string jwtVc, string publicKey)
     {
         Log.Information($"Verifying credential for holder"); // todo: deserialize jwt to log information
 

--- a/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
@@ -1,0 +1,7 @@
+﻿using OpenID4VC_Prototype.Domain.Models;
+
+namespace OpenID4VC_Prototype.Domain.Interfaces;
+public interface IJwtService
+{
+    string CreateJwtVc(VerifiableCredential verifiableCredential);
+}

--- a/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
@@ -4,4 +4,5 @@ namespace OpenID4VC_Prototype.Domain.Interfaces;
 public interface IJwtService
 {
     string CreateJwtVc(VerifiableCredential verifiableCredential);
+    bool ValidateJwtVc(string jwtVc);
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
@@ -3,6 +3,6 @@
 namespace OpenID4VC_Prototype.Domain.Interfaces;
 public interface IJwtService
 {
-    string CreateJwtVc(VerifiableCredential verifiableCredential);
+    string CreateJwtVc(VerifiableCredential verifiableCredential, string privateKey);
     bool ValidateJwtVc(string jwtVc);
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
@@ -1,6 +1,7 @@
 ﻿using OpenID4VC_Prototype.Domain.Models;
 
 namespace OpenID4VC_Prototype.Domain.Interfaces;
+
 public interface IJwtService
 {
     string CreateJwtVc(VerifiableCredential verifiableCredential, string privateKey);

--- a/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
@@ -1,8 +1,9 @@
-﻿using OpenID4VC_Prototype.Domain.Models;
+﻿using System.Security.Cryptography;
+using OpenID4VC_Prototype.Domain.Models;
 
 namespace OpenID4VC_Prototype.Domain.Interfaces;
 public interface IJwtService
 {
-    string CreateJwtVc(VerifiableCredential verifiableCredential, string privateKey);
-    bool ValidateJwtVc(string jwtVc);
+    string CreateJwtVc(VerifiableCredential verifiableCredential);
+    bool ValidateJwtVc(string jwtVc, RSA publicKey);
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
@@ -1,5 +1,4 @@
-﻿using System.Security.Cryptography;
-using OpenID4VC_Prototype.Domain.Models;
+﻿using OpenID4VC_Prototype.Domain.Models;
 
 namespace OpenID4VC_Prototype.Domain.Interfaces;
 public interface IJwtService

--- a/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Domain/Interfaces/IJwtService.cs
@@ -4,6 +4,6 @@ using OpenID4VC_Prototype.Domain.Models;
 namespace OpenID4VC_Prototype.Domain.Interfaces;
 public interface IJwtService
 {
-    string CreateJwtVc(VerifiableCredential verifiableCredential);
-    bool ValidateJwtVc(string jwtVc, RSA publicKey);
+    string CreateJwtVc(VerifiableCredential verifiableCredential, string privateKey);
+    bool ValidateJwtVc(string jwtVc, string publicKey);
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Domain/Services/JwtService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Domain/Services/JwtService.cs
@@ -1,5 +1,6 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using Microsoft.IdentityModel.Tokens;
 using OpenID4VC_Prototype.Domain.Interfaces;
 using OpenID4VC_Prototype.Domain.Models;
 
@@ -21,5 +22,26 @@ public class JwtService : IJwtService
         );
 
         return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    public bool ValidateJwtVc(string jwtVc)
+    {
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var validationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateIssuerSigningKey = true
+        };
+
+        try
+        {
+            tokenHandler.ValidateToken(jwtVc, validationParameters, out _);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
     }
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Domain/Services/JwtService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Domain/Services/JwtService.cs
@@ -1,16 +1,17 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using OpenID4VC_Prototype.Domain.Interfaces;
 using OpenID4VC_Prototype.Domain.Models;
 
 namespace OpenID4VC_Prototype.Domain.Services;
-public class JwtService
+public class JwtService : IJwtService
 {
     public string CreateJwtVc(VerifiableCredential verifiableCredential)
     {
         var claims = new[]
         {
-            new Claim("issuer", verifiableCredential.IssuerDId),
-            new Claim("holder", verifiableCredential.HolderDId),
+            new Claim("iss", verifiableCredential.IssuerDId),
+            new Claim("sub", verifiableCredential.HolderDId),
             new Claim("type", verifiableCredential.CredentialType)
         };
 

--- a/ProtoCredentials/OpenID4VC-Prototype/Domain/Services/JwtService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Domain/Services/JwtService.cs
@@ -1,0 +1,24 @@
+﻿using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using OpenID4VC_Prototype.Domain.Models;
+
+namespace OpenID4VC_Prototype.Domain.Services;
+public class JwtService
+{
+    public string CreateJwtVc(VerifiableCredential verifiableCredential)
+    {
+        var claims = new[]
+        {
+            new Claim("issuer", verifiableCredential.IssuerDId),
+            new Claim("holder", verifiableCredential.HolderDId),
+            new Claim("type", verifiableCredential.CredentialType)
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: verifiableCredential.IssuerDId,
+            claims: claims
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/ProtoCredentials/OpenID4VC-Prototype/Domain/Services/JwtService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Domain/Services/JwtService.cs
@@ -5,12 +5,15 @@ using OpenID4VC_Prototype.Domain.Interfaces;
 using OpenID4VC_Prototype.Domain.Models;
 
 namespace OpenID4VC_Prototype.Domain.Services;
-public class JwtService(RSA privateKey) : IJwtService
+public class JwtService : IJwtService
 {
-    private readonly RSA _privateKey = privateKey;
+    //private readonly RSA _privateKey = privateKey;
 
-    public string CreateJwtVc(VerifiableCredential credential)
+    public string CreateJwtVc(VerifiableCredential credential, string privateKey)
     {
+        var rsa = RSA.Create();
+        rsa.ImportRSAPrivateKey(Convert.FromBase64String(privateKey), out _);
+
         var tokenDescriptor = new SecurityTokenDescriptor
         {
             Issuer = credential.IssuerDId,
@@ -21,7 +24,7 @@ public class JwtService(RSA privateKey) : IJwtService
                 {"iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds()}
             },
             Expires = DateTime.UtcNow.AddMinutes(5),
-            SigningCredentials = new SigningCredentials(new RsaSecurityKey(_privateKey), SecurityAlgorithms.RsaSha256)
+            SigningCredentials = new SigningCredentials(new RsaSecurityKey(rsa), SecurityAlgorithms.RsaSha256)
         };
 
         var handler = new JwtSecurityTokenHandler();
@@ -29,17 +32,20 @@ public class JwtService(RSA privateKey) : IJwtService
         return handler.WriteToken(token);
     }
 
-    public bool ValidateJwtVc(string jwtVc, RSA publicKey)
+    public bool ValidateJwtVc(string jwtVc, string publicKey)
     {
         var tokenHandler = new JwtSecurityTokenHandler();
 
+        var rsa = RSA.Create();
+        rsa.ImportRSAPublicKey(Convert.FromBase64String(publicKey), out _);
+
         var validationParameters = new TokenValidationParameters
         {
-            ValidateIssuer = true,
+            ValidateIssuer = false,
             ValidIssuer = "did:example:issuer",
             ValidateAudience = false,
             ValidateLifetime = true,
-            IssuerSigningKey = new RsaSecurityKey(publicKey),
+            IssuerSigningKey = new RsaSecurityKey(rsa),
             ValidateIssuerSigningKey = true
         };
 

--- a/ProtoCredentials/OpenID4VC-Prototype/Domain/Services/JwtService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Domain/Services/JwtService.cs
@@ -5,6 +5,7 @@ using OpenID4VC_Prototype.Domain.Interfaces;
 using OpenID4VC_Prototype.Domain.Models;
 
 namespace OpenID4VC_Prototype.Domain.Services;
+
 public class JwtService : IJwtService
 {
     //private readonly RSA _privateKey = privateKey;

--- a/ProtoCredentials/OpenID4VC-Prototype/Domain/Services/JwtService.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Domain/Services/JwtService.cs
@@ -1,49 +1,45 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
 using System.Security.Cryptography;
-using System.Text;
 using Microsoft.IdentityModel.Tokens;
 using OpenID4VC_Prototype.Domain.Interfaces;
 using OpenID4VC_Prototype.Domain.Models;
 
 namespace OpenID4VC_Prototype.Domain.Services;
-public class JwtService : IJwtService
+public class JwtService(RSA privateKey) : IJwtService
 {
-    public string CreateJwtVc(VerifiableCredential credential, string privateKeyBase64)
+    private readonly RSA _privateKey = privateKey;
+
+    public string CreateJwtVc(VerifiableCredential credential)
     {
-        //var claims = new[]
-        //{
-        //    new Claim("iss", credential.IssuerDId),
-        //    new Claim("sub", credential.HolderDId),
-        //    new Claim("type", credential.CredentialType)
-        //};
-
-        var rsa = RSA.Create();
-        rsa.ImportRSAPrivateKey(Convert.FromBase64String(privateKeyBase64), out _);
-
-        var tokenData = new SecurityTokenDescriptor
+        var tokenDescriptor = new SecurityTokenDescriptor
         {
             Issuer = credential.IssuerDId,
             Claims = new Dictionary<string, object>
             {
                 {"sub", credential.HolderDId },
-                {"credential", credential.Claims }
+                {"credential", credential.Claims },
+                {"iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds()}
             },
-            SigningCredentials = new SigningCredentials(new RsaSecurityKey(rsa), SecurityAlgorithms.RsaSha256)
+            Expires = DateTime.UtcNow.AddMinutes(5),
+            SigningCredentials = new SigningCredentials(new RsaSecurityKey(_privateKey), SecurityAlgorithms.RsaSha256)
         };
 
         var handler = new JwtSecurityTokenHandler();
-        var token = handler.CreateToken(tokenData);
+        var token = handler.CreateToken(tokenDescriptor);
         return handler.WriteToken(token);
     }
 
-    public bool ValidateJwtVc(string jwtVc)
+    public bool ValidateJwtVc(string jwtVc, RSA publicKey)
     {
         var tokenHandler = new JwtSecurityTokenHandler();
+
         var validationParameters = new TokenValidationParameters
         {
             ValidateIssuer = true,
-            ValidateAudience = true,
+            ValidIssuer = "did:example:issuer",
+            ValidateAudience = false,
+            ValidateLifetime = true,
+            IssuerSigningKey = new RsaSecurityKey(publicKey),
             ValidateIssuerSigningKey = true
         };
 

--- a/ProtoCredentials/OpenID4VC-Prototype/OpenID4VC-Prototype.csproj
+++ b/ProtoCredentials/OpenID4VC-Prototype/OpenID4VC-Prototype.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.4.0" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
@@ -57,7 +57,7 @@ public static class Presentation
         try
         {
             var issuerDto = issuer.Adapt<DIdDto>();
-            jwtCredential = issuerService.IssueJwtVc(issuerDto, holder.DId);
+            jwtCredential = issuerService.IssueJwtCredential(issuerDto, holder.DId);
         }
         catch (Exception ex)
         {
@@ -68,7 +68,7 @@ public static class Presentation
         WriteTitle("Verifier receives JWT and validates credential");
         try
         {
-            var validationResult = verifierService.ValidateJwtVc(jwtCredential, issuer.PublicKey);
+            var validationResult = verifierService.ValidateJwtCredential(jwtCredential, issuer.PublicKey);
 
             Log.Information(validationResult.IsValid
                 ? "Credential is valid!"

--- a/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
@@ -8,7 +8,7 @@ namespace OpenID4VC_Prototype.Presentation.Console;
 
 public static class Presentation
 {
-    public static void PresentVCFlow(DecentralizedIdentifier issuer, IIssuerService issuerService, DecentralizedIdentifier holder, IVerifierService verifierService)
+    public static void PresentVcFlow(DecentralizedIdentifier issuer, IIssuerService issuerService, DecentralizedIdentifier holder, IVerifierService verifierService)
     {
         // Issuing a verifiable credential
         WriteTitle("Issuing verifiable credential");

--- a/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
@@ -82,7 +82,6 @@ public static class Presentation
 
     private static void WriteTitle(string title)
     {
-        System.Console.WriteLine();
-        System.Console.WriteLine("***" + title.ToUpper());
+        System.Console.WriteLine("/n***" + title.ToUpper());
     }
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
@@ -82,6 +82,6 @@ public static class Presentation
 
     private static void WriteTitle(string title)
     {
-        System.Console.WriteLine("/n***" + title.ToUpper());
+        System.Console.WriteLine("\n***" + title.ToUpper());
     }
 }

--- a/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
@@ -52,21 +52,20 @@ public static class Presentation
     public static void ShowJwtVcFlow(DecentralizedIdentifier issuer, IIssuerService issuerService, DecentralizedIdentifier holder, IVerifierService verifierService)
     {
         // Issuing JWT verifiable credential
-        WriteTitle("Issuing JWT credential");
-        string jwtCredential;
+        WriteTitle("Issuing verifiable credential via JWT");
+        var jwtCredential = string.Empty;
         try
         {
             var issuerDto = issuer.Adapt<DIdDto>();
             jwtCredential = issuerService.IssueJwtVc(issuerDto, holder.DId);
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
-            System.Console.WriteLine(e);
-            throw;
+            Log.Fatal(ex, $"Unexpected error: {ex.Message}");
         }
 
         // Validating JWT credential
-        WriteTitle("Validating JWT credential");
+        WriteTitle("Verifier receives JWT and validates credential");
         try
         {
             var validationResult = verifierService.ValidateJwtVc(jwtCredential, issuer.PublicKey);
@@ -75,10 +74,9 @@ public static class Presentation
                 ? "Credential is valid!"
                 : $"Verification failed: {validationResult.ErrorMessage}");
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
-            System.Console.WriteLine(e);
-            throw;
+            Log.Fatal(ex, $"Unexpected error: {ex.Message}");
         }
     }
 

--- a/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
@@ -49,7 +49,40 @@ public static class Presentation
         }
     }
 
-    static void WriteTitle(string title)
+    public static void PresentJWtVcFlow(DecentralizedIdentifier issuer, IIssuerService issuerService, DecentralizedIdentifier holder, IVerifierService verifierService)
+    {
+        // Issuing JWT verifiable credential
+        WriteTitle("Issuing JWT credential");
+        string jwtCredential;
+        try
+        {
+            var issuerDto = issuer.Adapt<DIdDto>();
+            jwtCredential = issuerService.IssueJwtVc(issuerDto, holder.DId);
+        }
+        catch (Exception e)
+        {
+            System.Console.WriteLine(e);
+            throw;
+        }
+
+        // Validating JWT credential
+        WriteTitle("Validating JWT credential");
+        try
+        {
+            var validationResult = verifierService.ValidateJwtVc(jwtCredential, issuer.PublicKey);
+
+            Log.Information(validationResult.IsValid
+                ? "Credential is valid!"
+                : $"Verification failed: {validationResult.ErrorMessage}");
+        }
+        catch (Exception e)
+        {
+            System.Console.WriteLine(e);
+            throw;
+        }
+    }
+
+    private static void WriteTitle(string title)
     {
         System.Console.WriteLine();
         System.Console.WriteLine("***" + title.ToUpper());

--- a/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Presentation/Console/Presentation.cs
@@ -8,7 +8,7 @@ namespace OpenID4VC_Prototype.Presentation.Console;
 
 public static class Presentation
 {
-    public static void PresentVcFlow(DecentralizedIdentifier issuer, IIssuerService issuerService, DecentralizedIdentifier holder, IVerifierService verifierService)
+    public static void ShowVcFlow(DecentralizedIdentifier issuer, IIssuerService issuerService, DecentralizedIdentifier holder, IVerifierService verifierService)
     {
         // Issuing a verifiable credential
         WriteTitle("Issuing verifiable credential");
@@ -49,7 +49,7 @@ public static class Presentation
         }
     }
 
-    public static void PresentJWtVcFlow(DecentralizedIdentifier issuer, IIssuerService issuerService, DecentralizedIdentifier holder, IVerifierService verifierService)
+    public static void ShowJwtVcFlow(DecentralizedIdentifier issuer, IIssuerService issuerService, DecentralizedIdentifier holder, IVerifierService verifierService)
     {
         // Issuing JWT verifiable credential
         WriteTitle("Issuing JWT credential");

--- a/ProtoCredentials/OpenID4VC-Prototype/Program.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Program.cs
@@ -84,6 +84,36 @@ catch (Exception ex)
     Log.Fatal(ex, $"Unexpected error: {ex.Message}");
 }
 
+// Issuing JWT verifiable credential
+WriteTitle("Issuing JWT credential");
+string jwtCredential;
+try
+{
+    var issuerDto = issuer.Adapt<DIdDto>();
+    jwtCredential = issuerService.IssueJwtVc(issuerDto, holder.DId);
+}
+catch (Exception e)
+{
+    Console.WriteLine(e);
+    throw;
+}
+
+// Validating JWT credential
+WriteTitle("Validating JWT credential");
+try
+{
+    var validationResult = verifierService.ValidateJwtVc(jwtCredential);
+
+    Log.Information(validationResult.IsValid
+        ? "Credential is valid!"
+        : $"Verification failed: {validationResult.ErrorMessage}");
+}
+catch (Exception e)
+{
+    Console.WriteLine(e);
+    throw;
+}
+
 Log.CloseAndFlush();
 
 return;

--- a/ProtoCredentials/OpenID4VC-Prototype/Program.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Program.cs
@@ -29,6 +29,7 @@ var builder = Host.CreateDefaultBuilder(args)
         services.AddScoped<IIssuerService, IssuerService>();
         services.AddScoped<IVerifierService, VerifierService>();
         services.AddSingleton<DIdService>();
+        services.AddScoped<IJwtService, JwtService>();
     }).Build();
 
 using var scope = builder.Services.CreateScope();

--- a/ProtoCredentials/OpenID4VC-Prototype/Program.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Program.cs
@@ -46,7 +46,7 @@ Console.WriteLine($"Holder DID: {holder.DId}");
 Console.WriteLine($"Verifier DID: {verifier.DId}");
 
 Presentation.ShowVcFlow(issuer, issuerService, holder, verifierService);
-Console.WriteLine("\n************************");
+Console.WriteLine("\n===================");
 Presentation.ShowJwtVcFlow(issuer, issuerService, holder, verifierService);
 
 Log.CloseAndFlush();

--- a/ProtoCredentials/OpenID4VC-Prototype/Program.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Program.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Mapster;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using OpenID4VC_Prototype.Application.Interfaces;
+using OpenID4VC_Prototype.Application.Models;
 using OpenID4VC_Prototype.Application.Services;
 using OpenID4VC_Prototype.Domain.Interfaces;
 using OpenID4VC_Prototype.Domain.Services;
@@ -47,8 +49,9 @@ Console.WriteLine($"Verifier DID: {verifier.DId}");
 
 Presentation.PresentVCFlow(issuer, issuerService, holder, verifierService);
 
+Console.WriteLine("JWT flow:");
 // Issuing JWT verifiable credential
-WriteTitle("Issuing JWT credential");
+//WriteTitle("Issuing JWT credential");
 string jwtCredential;
 try
 {
@@ -62,7 +65,7 @@ catch (Exception e)
 }
 
 // Validating JWT credential
-WriteTitle("Validating JWT credential");
+//WriteTitle("Validating JWT credential");
 try
 {
     var validationResult = verifierService.ValidateJwtVc(jwtCredential);

--- a/ProtoCredentials/OpenID4VC-Prototype/Program.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Program.cs
@@ -68,7 +68,7 @@ catch (Exception e)
 //WriteTitle("Validating JWT credential");
 try
 {
-    var validationResult = verifierService.ValidateJwtVc(jwtCredential);
+    var validationResult = verifierService.ValidateJwtVc(jwtCredential, issuer.PublicKey);
 
     Log.Information(validationResult.IsValid
         ? "Credential is valid!"

--- a/ProtoCredentials/OpenID4VC-Prototype/Program.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Program.cs
@@ -46,8 +46,7 @@ Console.WriteLine($"Holder DID: {holder.DId}");
 Console.WriteLine($"Verifier DID: {verifier.DId}");
 
 Presentation.ShowVcFlow(issuer, issuerService, holder, verifierService);
-Console.WriteLine();
-Console.WriteLine("************************");
+Console.WriteLine("\n************************");
 Presentation.ShowJwtVcFlow(issuer, issuerService, holder, verifierService);
 
 Log.CloseAndFlush();

--- a/ProtoCredentials/OpenID4VC-Prototype/Program.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Program.cs
@@ -46,6 +46,7 @@ Console.WriteLine($"Holder DID: {holder.DId}");
 Console.WriteLine($"Verifier DID: {verifier.DId}");
 
 Presentation.ShowVcFlow(issuer, issuerService, holder, verifierService);
+Console.WriteLine();
 Console.WriteLine("************************");
 Presentation.ShowJwtVcFlow(issuer, issuerService, holder, verifierService);
 

--- a/ProtoCredentials/OpenID4VC-Prototype/Program.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Program.cs
@@ -45,7 +45,7 @@ Console.WriteLine($"Issuer DID: {issuer.DId}");
 Console.WriteLine($"Holder DID: {holder.DId}");
 Console.WriteLine($"Verifier DID: {verifier.DId}");
 
-Presentation.PresentVcFlow(issuer, issuerService, holder, verifierService);
-Presentation.PresentJWtVcFlow(issuer, issuerService, holder, verifierService);
+Presentation.ShowVcFlow(issuer, issuerService, holder, verifierService);
+Presentation.ShowJwtVcFlow(issuer, issuerService, holder, verifierService);
 
 Log.CloseAndFlush();

--- a/ProtoCredentials/OpenID4VC-Prototype/Program.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Program.cs
@@ -1,9 +1,7 @@
-﻿using Mapster;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using OpenID4VC_Prototype.Application.Interfaces;
-using OpenID4VC_Prototype.Application.Models;
 using OpenID4VC_Prototype.Application.Services;
 using OpenID4VC_Prototype.Domain.Interfaces;
 using OpenID4VC_Prototype.Domain.Services;
@@ -48,36 +46,6 @@ Console.WriteLine($"Holder DID: {holder.DId}");
 Console.WriteLine($"Verifier DID: {verifier.DId}");
 
 Presentation.PresentVcFlow(issuer, issuerService, holder, verifierService);
-
-Console.WriteLine("JWT flow:");
-// Issuing JWT verifiable credential
-//WriteTitle("Issuing JWT credential");
-string jwtCredential;
-try
-{
-    var issuerDto = issuer.Adapt<DIdDto>();
-    jwtCredential = issuerService.IssueJwtVc(issuerDto, holder.DId);
-}
-catch (Exception e)
-{
-    Console.WriteLine(e);
-    throw;
-}
-
-// Validating JWT credential
-//WriteTitle("Validating JWT credential");
-try
-{
-    var validationResult = verifierService.ValidateJwtVc(jwtCredential, issuer.PublicKey);
-
-    Log.Information(validationResult.IsValid
-        ? "Credential is valid!"
-        : $"Verification failed: {validationResult.ErrorMessage}");
-}
-catch (Exception e)
-{
-    Console.WriteLine(e);
-    throw;
-}
+Presentation.PresentJWtVcFlow(issuer, issuerService, holder, verifierService);
 
 Log.CloseAndFlush();

--- a/ProtoCredentials/OpenID4VC-Prototype/Program.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Program.cs
@@ -46,6 +46,7 @@ Console.WriteLine($"Holder DID: {holder.DId}");
 Console.WriteLine($"Verifier DID: {verifier.DId}");
 
 Presentation.ShowVcFlow(issuer, issuerService, holder, verifierService);
+Console.WriteLine("************************");
 Presentation.ShowJwtVcFlow(issuer, issuerService, holder, verifierService);
 
 Log.CloseAndFlush();

--- a/ProtoCredentials/OpenID4VC-Prototype/Program.cs
+++ b/ProtoCredentials/OpenID4VC-Prototype/Program.cs
@@ -47,7 +47,7 @@ Console.WriteLine($"Issuer DID: {issuer.DId}");
 Console.WriteLine($"Holder DID: {holder.DId}");
 Console.WriteLine($"Verifier DID: {verifier.DId}");
 
-Presentation.PresentVCFlow(issuer, issuerService, holder, verifierService);
+Presentation.PresentVcFlow(issuer, issuerService, holder, verifierService);
 
 Console.WriteLine("JWT flow:");
 // Issuing JWT verifiable credential

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # HappyCredentials
+
 ## ProtoCredentials
-Console app that illustrates OpenId4VC flow
+Console app that illustrates OpenId4VC flow in accordance to draft 15
 
 ## License
 This project is licensed under the [Apache 2.0 License](LICENSE).


### PR DESCRIPTION
# Description
The `JWT` creation and verification is implemented.

- New service is added to the `Domain` layer to create and verify the tokens
- New, token related, methods are added to the `Issuer` and `Verifier` services
- Method to start the new flow is added to the `Presentation` 

 This means that `VCs` are now wrapped inside `JWT` when created and sent. This is more in accordance to the OpenID4VC specification.

Before, the `VCs` where sent just as they are between the entities when running the prototype. This does not adhere to the OpenId4VC specification.
